### PR TITLE
implements `Deref<Target=str>`, `Display`, `AsRef`, `FromStr` ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,19 @@ url_parse/servo_parse   time:   [5.5127 µs 5.6287 µs 5.8046 µs]
 Found 2 outliers among 100 measurements (2.00%)
   2 (2.00%) high severe
 ```
+
+### Implemented traits
+
+`Url` implements the following traits.
+| Trait(s) | Description |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **[`Display`](https://doc.rust-lang.org/std/fmt/trait.Display.html)** | Provides `to_string` and allows for the value to be used in [format!](https://doc.rust-lang.org/std/fmt/fn.format.html) macros (e.g. `println!`). |
+| **[`Debug`](https://doc.rust-lang.org/std/fmt/trait.Debug.html)** | Allows debugger output in format macros, (`{:?}` syntax) |
+| **[`PartialEq`](https://doc.rust-lang.org/std/cmp/trait.PartialEq.html), [`Eq`](https://doc.rust-lang.org/std/cmp/trait.Eq.html)** | Allows for comparison, `url1 == url2`, `url1.eq(url2)` |
+| **[`PartialOrd`](https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html), [`Ord`](https://doc.rust-lang.org/std/cmp/trait.Ord.html)** | Allows for ordering `url1 < url2`, done so alphabetically. This is also allows `Url` to be used as a key in a [`BTreeMap`](https://doc.rust-lang.org/std/collections/struct.BTreeMap.html) |
+| **[`Hash`](https://doc.rust-lang.org/std/hash/trait.Hash.html)** | Makes it so that `Url` can be hashed based on the string representation. This is important so that `Url` can be used as a key in a [`HashMap`](https://doc.rust-lang.org/std/collections/struct.HashMap.html) |
+| **[`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html)** | Allows for use with [`str`'s `parse` method](https://doc.rust-lang.org/std/primitive.str.html#method.parse) |
+| **[`TryFrom<String>`, `TryFrom<&str>`](https://doc.rust-lang.org/std/convert/trait.TryFrom.html)** | Provides `try_into` methods for `String` and `&str` |
+| **[`Borrow<str>`](https://doc.rust-lang.org/std/borrow/trait.Borrow.html), [`Borrow<[u8]>`](https://doc.rust-lang.org/std/borrow/trait.Borrow.html)** | Used in some crates so that the `Url` can be used as a key. |
+| **[`Deref<Target=str>`](https://doc.rust-lang.org/std/ops/trait.Deref.html)** | Allows for `&Url` to dereference as a `&str`. Also provides a [number of string methods](https://doc.rust-lang.org/std/string/struct.String.html#deref-methods-str) |
+| **[`AsRef<[u8]>`](https://doc.rust-lang.org/std/convert/trait.AsRef.html), [`AsRef<str>`](https://doc.rust-lang.org/std/convert/trait.AsRef.html)** | Used to do a cheap reference-to-reference conversion. |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,6 +223,7 @@ impl Url {
     }
 
     /// Return the parsed version of the URL with all components.
+    ///
     /// For more information, read [WHATWG URL spec](https://url.spec.whatwg.org/#dom-url-href)
     pub fn href(&self) -> &str {
         unsafe { ffi::ada_get_href(self.url) }.as_str()
@@ -445,6 +446,30 @@ impl Url {
 
     pub fn has_search(&self) -> bool {
         unsafe { ffi::ada_has_search(self.url) }
+    }
+    /// Returns the parsed version of the URL with all components.
+    ///
+    /// For more information, read [WHATWG URL spec](https://url.spec.whatwg.org/#dom-url-href)
+    pub fn as_str(&self) -> &str {
+        self.href()
+    }
+}
+
+impl std::ops::Deref for Url {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        self.href()
+    }
+}
+impl AsRef<str> for Url {
+    fn as_ref(&self) -> &str {
+        self.href()
+    }
+}
+
+impl std::fmt::Display for Url {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.href())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ pub enum Error {
     #[error("Invalid url: \"{0}\"")]
     ParseUrl(String),
 }
-#[derive(Clone)]
+
 pub struct Url {
     url: *mut ffi::ada_url,
 }
@@ -666,6 +666,7 @@ mod test {
     // fn clone_should_create_new_instance() {
     //     let url = Url::parse("http://example.com/", None).expect("Should have parsed url");
     //     let cloned = url.clone();
+    //     println!("{cloned}");
     //     assert_eq!(url, cloned);
     //     assert_ne!(url.as_ptr(), cloned.as_ptr());
     // }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -473,6 +473,14 @@ impl std::fmt::Display for Url {
     }
 }
 
+impl std::str::FromStr for Url {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s, None)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -558,17 +558,13 @@ impl std::str::FromStr for Url {
 
 #[cfg(test)]
 mod test {
-
     use super::*;
     #[test]
     fn should_display_serialization() {
         let tests = [
             ("http://example.com/", "http://example.com/"),
             ("HTTP://EXAMPLE.COM", "http://example.com/"),
-            (
-                "http://user:pwd@domain:8080.com",
-                "http://user:pwd@domain:8080.com/",
-            ),
+            ("http://user:pwd@domain.com", "http://user:pwd@domain.com/"),
         ];
         for (value, expected) in tests {
             let url = Url::parse(value, None).expect("Should have parsed url");
@@ -613,13 +609,13 @@ mod test {
             );
         }
     }
-    #[test]
-    fn clone_should_create_new_instance() {
-        let url = Url::parse("http://example.com/", None).expect("Should have parsed url");
-        let cloned = url.clone();
-        assert_eq!(url, cloned);
-        assert_ne!(url.as_ptr(), cloned.as_ptr());
-    }
+    // #[test]
+    // fn clone_should_create_new_instance() {
+    //     let url = Url::parse("http://example.com/", None).expect("Should have parsed url");
+    //     let cloned = url.clone();
+    //     assert_eq!(url, cloned);
+    //     assert_ne!(url.as_ptr(), cloned.as_ptr());
+    // }
     #[test]
     fn should_order_alphabetically() {
         let left = Url::parse("https://example.com/", None).expect("Should have parsed url");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ pub mod ffi {
             base: *const c_char,
             base_length: usize,
         ) -> bool;
-        pub fn ada_get_components(url: *mut ada_url) -> ada_url_components;
+        pub fn ada_get_components(url: *mut ada_url) -> *mut ada_url_components;
 
         // Getters
         pub fn ada_get_origin(url: *mut ada_url) -> ada_owned_string;
@@ -502,18 +502,20 @@ impl std::convert::AsRef<[u8]> for Url {
 
 impl std::fmt::Debug for Url {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let components = unsafe { ffi::ada_get_components(self.url) };
-        f.debug_struct("Url")
-            .field("href", &self.href())
-            .field("protocol_end", &components.protocol_end)
-            .field("username_end", &components.username_end)
-            .field("host_start", &components.host_start)
-            .field("host_end", &components.host_end)
-            .field("port", &components.port)
-            .field("pathname_start", &components.pathname_start)
-            .field("search_start", &components.search_start)
-            .field("hash_start", &components.hash_start)
-            .finish()
+        unsafe {
+            let components = ffi::ada_get_components(self.url).as_ref().unwrap();
+            f.debug_struct("Url")
+                .field("href", &self.href())
+                .field("protocol_end", &components.protocol_end)
+                .field("username_end", &components.username_end)
+                .field("host_start", &components.host_start)
+                .field("host_end", &components.host_end)
+                .field("port", &components.port)
+                .field("pathname_start", &components.pathname_start)
+                .field("search_start", &components.search_start)
+                .field("hash_start", &components.hash_start)
+                .finish()
+        }
     }
 }
 
@@ -577,7 +579,7 @@ mod test {
         let tests = [("https://www.ada-url.com/playground")];
         for value in tests {
             let url = Url::parse(value, None).expect("Should have parsed url");
-            println!("{:?}", url);
+            println!("{:#?}", url);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -504,16 +504,46 @@ impl std::fmt::Debug for Url {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         unsafe {
             let components = ffi::ada_get_components(self.url).as_ref().unwrap();
-            f.debug_struct("Url")
+
+            let mut debug = f.debug_struct("Url");
+
+            debug
                 .field("href", &self.href())
                 .field("protocol_end", &components.protocol_end)
-                .field("username_end", &components.username_end)
                 .field("host_start", &components.host_start)
-                .field("host_end", &components.host_end)
-                .field("port", &components.port)
-                .field("pathname_start", &components.pathname_start)
-                .field("search_start", &components.search_start)
-                .field("hash_start", &components.hash_start)
+                .field("host_end", &components.host_end);
+            let port = if components.port == u32::MAX {
+                Some(components.port)
+            } else {
+                None
+            };
+            let username_end = if components.username_end == u32::MAX {
+                None
+            } else {
+                Some(components.username_end)
+            };
+            let search_start = if components.search_start == u32::MAX {
+                None
+            } else {
+                Some(components.search_start)
+            };
+            let hash_start = if components.hash_start == u32::MAX {
+                None
+            } else {
+                Some(components.hash_start)
+            };
+            let pathname_start = if components.pathname_start == u32::MAX {
+                None
+            } else {
+                Some(components.pathname_start)
+            };
+
+            debug
+                .field("port", &port)
+                .field("username_end", &username_end)
+                .field("search_start", &search_start)
+                .field("hash_start", &hash_start)
+                .field("pathname_start", &pathname_start)
                 .finish()
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -602,16 +602,6 @@ mod test {
     use super::*;
 
     #[test]
-    fn spike_debug() {
-        // TODO: This is a spike test to see if the debug output is correct. Update or remove this test once clarified that the output is as expected - @chanced
-        let tests = [("https://www.ada-url.com/playground")];
-        for value in tests {
-            let url = Url::parse(value, None).expect("Should have parsed url");
-            println!("{:#?}", url);
-        }
-    }
-
-    #[test]
     fn should_display_serialization() {
         let tests = [
             ("http://example.com/", "http://example.com/"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -652,14 +652,6 @@ mod test {
             );
         }
     }
-    // #[test]
-    // fn clone_should_create_new_instance() {
-    //     let url = Url::parse("http://example.com/", None).expect("Should have parsed url");
-    //     let cloned = url.clone();
-    //     println!("{cloned}");
-    //     assert_eq!(url, cloned);
-    //     assert_ne!(url.as_ptr(), cloned.as_ptr());
-    // }
     #[test]
     fn should_order_alphabetically() {
         let left = Url::parse("https://example.com/", None).expect("Should have parsed url");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -576,7 +576,20 @@ mod test {
             assert_eq!(url.to_string(), expected);
         }
     }
-
+    #[test]
+    fn should_parse_with_try_from() {
+        let tests = [("http://example.com/", true), ("invalid url", false)];
+        for (value, should_parse) in tests {
+            let url = Url::parse("http://example.com/", None).unwrap();
+            let parsed = Url::try_from(value);
+            if should_parse {
+                assert_eq!(parsed.is_ok(), should_parse);
+                assert_eq!(url, parsed.unwrap());
+            } else {
+                assert!(parsed.is_err());
+            }
+        }
+    }
     #[test]
     fn should_compare_urls() {
         let tests = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -504,18 +504,16 @@ impl std::fmt::Debug for Url {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         unsafe {
             let components = ffi::ada_get_components(self.url).as_ref().unwrap();
-
             let mut debug = f.debug_struct("Url");
-
             debug
                 .field("href", &self.href())
                 .field("protocol_end", &components.protocol_end)
                 .field("host_start", &components.host_start)
                 .field("host_end", &components.host_end);
             let port = if components.port == u32::MAX {
-                Some(components.port)
-            } else {
                 None
+            } else {
+                Some(components.port)
             };
             let username_end = if components.username_end == u32::MAX {
                 None


### PR DESCRIPTION
This implements a few nice-to-haves for the `Url` type, such as

- `Deref<Target=str>` so that `&Url` can be passed anywhere that expects `&str` plus all methods implemented for `Deref<Target=str>`
- `std::convert::AsRef<str>`
- `std::fmt::Display`, so that formatting the `Url` works as expected, also provides `to_string`.
- `std::str::FromStr` for `str::parse` https://doc.rust-lang.org/std/primitive.str.html#method.parse

It also adds `as_str`, basically as an alias for `href`, for convention sake.