### PR TITLE
perf: update benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,21 +28,14 @@ fn main() {
 
 ### Performance
 
-Ada is fast. The benchmark below shows **2 times** faster URL parsing compared to `url`
+Ada is fast. The benchmark below shows **3.34 times** faster URL parsing compared to `url`
 
 ```
-     Running bench/parse.rs (target/release/deps/parse-dff65469468a2cec)
-url_parse/ada_parse     time:   [2.5853 µs 2.5982 µs 2.6115 µs]
-                        change: [-3.8745% -2.9874% -2.0620%] (p = 0.00 < 0.05)
-                        Performance has improved.
-Found 2 outliers among 100 measurements (2.00%)
-  1 (1.00%) low mild
-  1 (1.00%) high severe
-url_parse/servo_parse   time:   [5.5127 µs 5.6287 µs 5.8046 µs]
-                        change: [+0.7618% +3.0977% +6.5694%] (p = 0.01 < 0.05)
-                        Change within noise threshold.
-Found 2 outliers among 100 measurements (2.00%)
-  2 (2.00%) high severe
+parse/ada_url           time:   [2.0790 µs 2.0812 µs 2.0835 µs]
+                        thrpt:  [369.84 MiB/s 370.25 MiB/s 370.65 MiB/s]
+                        
+parse/url               time:   [6.9266 µs 6.9677 µs 7.0199 µs]
+                        thrpt:  [109.77 MiB/s 110.59 MiB/s 111.25 MiB/s]
 ```
 
 ### Implemented traits

--- a/bench/parse.rs
+++ b/bench/parse.rs
@@ -1,44 +1,38 @@
-use ada_url::Url;
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 
-const URL: &[&str] = &[
-    "https://www.google.com/",
-    "webhp?hl=en&amp;ictx=2&amp;sa=X&amp;ved=0ahUKEwil_",
-    "oSxzJj8AhVtEFkFHTHnCGQQPQgI",
-    "https://support.google.com/websearch/",
-    "?p=ws_results_help&amp;hl=en-CA&amp;fg=1",
+const URLS: &[&str] = &[
+    "https://www.google.com/webhp?hl=en&amp;ictx=2&amp;sa=X&amp;ved=0ahUKEwil_oSxzJj8AhVtEFkFHTHnCGQQPQgI",
+    "https://support.google.com/websearch/?p=ws_results_help&amp;hl=en-CA&amp;fg=1",
     "https://en.wikipedia.org/wiki/Dog#Roles_with_humans",
     "https://www.tiktok.com/@aguyandagolden/video/7133277734310038830",
-    "https://business.twitter.com/en/help/troubleshooting/",
-    "how-twitter-ads-work.html?ref=web-twc-ao-gbl-adsinfo&utm_source=twc&utm_",
-    "medium=web&utm_campaign=ao&utm_content=adsinfo",
-    "https://images-na.ssl-images-amazon.com/images/I/",
-    "41Gc3C8UysL.css?AUIClients/AmazonGatewayAuiAssets",
+    "https://business.twitter.com/en/help/troubleshooting/how-twitter-ads-work.html?ref=web-twc-ao-gbl-adsinfo&utm_source=twc&utm_medium=web&utm_campaign=ao&utm_content=adsinfo",
+    "https://images-na.ssl-images-amazon.com/images/I/41Gc3C8UysL.css?AUIClients/AmazonGatewayAuiAssets",
     "https://www.reddit.com/?after=t3_zvz1ze",
     "https://www.reddit.com/login/?dest=https%3A%2F%2Fwww.reddit.com%2F",
-    "postgresql://other:9818274x1!!@localhost:5432/",
-    "otherdb?connect_timeout=10&application_name=myapp",
+    "postgresql://other:9818274x1!!@localhost:5432/otherdb?connect_timeout=10&application_name=myapp",
     "http://192.168.1.1",            // ipv4
     "http://[2606:4700:4700::1111]", // ipv6
 ];
 
-fn bench_url_parse(b: &mut Criterion) {
-    b.benchmark_group("url_parse")
-        .bench_function("ada_parse", |b| {
-            b.iter(|| {
-                URL.iter().for_each(|url| {
-                    let _ = Url::parse(black_box(url), None);
-                });
+pub fn parse_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("parse");
+    group.throughput(Throughput::Bytes(URLS.iter().map(|u| u.len() as u64).sum()));
+    group.bench_function("ada_url", |b| {
+        b.iter(|| {
+            URLS.iter().for_each(|url| {
+                black_box(url).parse::<ada_url::Url>().unwrap();
             })
         })
-        .bench_function("servo_parse", |b| {
-            b.iter(|| {
-                URL.iter().for_each(|url| {
-                    let _ = url::Url::parse(black_box(url));
-                });
+    });
+    group.bench_function("url", |b| {
+        b.iter(|| {
+            URLS.iter().for_each(|url| {
+                black_box(url).parse::<url::Url>().unwrap();
             })
-        });
+        })
+    });
+    group.finish();
 }
 
-criterion_group!(benches, bench_url_parse);
+criterion_group!(benches, parse_benchmark);
 criterion_main!(benches);


### PR DESCRIPTION
```
     Running bench/parse.rs (target/release/deps/parse-90dae239da4bd51f)
parse/ada_url           time:   [2.0790 µs 2.0812 µs 2.0835 µs]
                        thrpt:  [369.84 MiB/s 370.25 MiB/s 370.65 MiB/s]
                 change:
                        time:   [+0.2255% +0.5063% +0.8385%] (p = 0.00 < 0.05)
                        thrpt:  [-0.8315% -0.5038% -0.2250%]
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe
parse/url               time:   [6.9266 µs 6.9677 µs 7.0199 µs]
                        thrpt:  [109.77 MiB/s 110.59 MiB/s 111.25 MiB/s]
                 change:
                        time:   [-0.3970% +0.0178% +0.5103%] (p = 0.94 > 0.05)
                        thrpt:  [-0.5077% -0.0178% +0.3986%]
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

```