### PR TITLE
feat: remove `mut`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,10 +121,10 @@ impl Url {
     /// ```
     /// use ada_url::Url;
     ///
-    /// let mut url = Url::parse("blob:https://example.com/foo", None).expect("Invalid URL");
+    /// let url = Url::parse("blob:https://example.com/foo", None).expect("Invalid URL");
     /// assert_eq!(url.origin(), "https://example.com");
     /// ```
-    pub fn origin(&mut self) -> &str {
+    pub fn origin(&self) -> &str {
         unsafe {
             let out = ffi::ada_get_origin(self.url);
             let slice = std::slice::from_raw_parts(out.data.cast(), out.length);


### PR DESCRIPTION
@anonrig Is there any reason `origin` must take mutable `self`? If not, this can be merged. If there is a reason, feel free to close this PR.