### PR TITLE
fix: properly `clone` url

### DIFF
--- a/deps/ada.cpp
+++ b/deps/ada.cpp
@@ -1,4 +1,4 @@
-/* auto-generated on 2023-08-25 15:25:45 -0400. Do not edit! */
+/* auto-generated on 2023-08-26 17:38:28 -0400. Do not edit! */
 /* begin file src/ada.cpp */
 #include "ada.h"
 /* begin file src/checkers.cpp */
@@ -14891,6 +14891,11 @@ void ada_free(ada_url result) noexcept {
   ada::result<ada::url_aggregator>* r =
       (ada::result<ada::url_aggregator>*)result;
   delete r;
+}
+
+ada_url ada_copy(ada_url input) noexcept {
+  ada::result<ada::url_aggregator>& r = get_instance(input);
+  return new ada::result<ada::url_aggregator>(r);
 }
 
 bool ada_is_valid(ada_url result) noexcept {

--- a/deps/ada.h
+++ b/deps/ada.h
@@ -1,4 +1,4 @@
-/* auto-generated on 2023-08-25 15:25:45 -0400. Do not edit! */
+/* auto-generated on 2023-08-26 17:38:28 -0400. Do not edit! */
 /* begin file include/ada.h */
 /**
  * @file ada.h
@@ -6922,14 +6922,14 @@ inline void url_search_params::sort() {
 #ifndef ADA_ADA_VERSION_H
 #define ADA_ADA_VERSION_H
 
-#define ADA_VERSION "2.6.2"
+#define ADA_VERSION "2.6.3"
 
 namespace ada {
 
 enum {
   ADA_VERSION_MAJOR = 2,
   ADA_VERSION_MINOR = 6,
-  ADA_VERSION_REVISION = 2,
+  ADA_VERSION_REVISION = 3,
 };
 
 }  // namespace ada

--- a/deps/ada_c.h
+++ b/deps/ada_c.h
@@ -51,6 +51,7 @@ bool ada_can_parse_with_base(const char* input, size_t input_length,
 
 void ada_free(ada_url result);
 void ada_free_owned_string(ada_owned_string owned);
+ada_url ada_copy(ada_url input);
 
 bool ada_is_valid(ada_url result);
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -59,6 +59,7 @@ extern "C" {
     ) -> *mut ada_url;
     pub fn ada_free(url: *mut ada_url);
     pub fn ada_free_owned_string(url: *mut ada_owned_string);
+    pub fn ada_copy(url: *mut ada_url) -> *mut ada_url;
     pub fn ada_is_valid(url: *mut ada_url) -> bool;
     pub fn ada_can_parse(url: *const c_char, length: usize) -> bool;
     pub fn ada_can_parse_with_base(


### PR DESCRIPTION
Thanks to @steveklabnik, Ada rust crate can have safe & correct cloning.

Co-authored-by: Steve Klabnik