### PR TITLE
feat: error type without allocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,10 +8,10 @@ version = "1.4.3"
 dependencies = [
  "cc",
  "criterion",
+ "derive_more",
  "link_args",
  "serde",
  "serde_json",
- "thiserror",
  "url",
 ]
 
@@ -117,6 +117,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +154,19 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -342,6 +361,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +398,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+
+[[package]]
 name = "serde"
 version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,7 +420,7 @@ checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -402,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -412,23 +446,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.44"
+name = "syn"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ libcpp = []
 serde = ["dep:serde"]
 
 [dependencies]
-thiserror = "1"
+derive_more = "0.99.17"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -523,7 +523,7 @@ impl Url {
         unsafe { ffi::ada_has_non_empty_username(self.0) }
     }
 
-    /// Returns true if URL has a non-empty pasword.
+    /// Returns true if URL has a non-empty password.
     pub fn has_non_empty_password(&self) -> bool {
         unsafe { ffi::ada_has_non_empty_password(self.0) }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,10 +42,12 @@ extern crate alloc;
 #[cfg(feature = "serde")]
 extern crate serde;
 
+/// Error type of [`Url::parse`].
 #[derive(Debug, Display, Error, PartialEq, Eq)]
 #[display(bound = "Input: std::fmt::Debug")]
 #[display(fmt = "Invalid url: {input:?}")]
 pub struct ParseUrlError<Input> {
+    /// The invalid input that caused the error.
     pub input: Input,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ extern crate serde;
 #[display(bound = "Input: std::fmt::Debug")]
 #[display(fmt = "Invalid url: {input:?}")]
 pub struct ParseUrlError<Input> {
-    input: Input,
+    pub input: Input,
 }
 
 /// Defines the type of the host.
@@ -782,6 +782,7 @@ mod test {
         dbg!(&url);
         let error = url.unwrap_err();
         assert_eq!(error.to_string(), r#"Invalid url: "this is not a url""#);
+        assert_eq!(error.input, "this is not a url");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,17 +35,18 @@ pub mod ffi;
 mod idna;
 pub use idna::Idna;
 
+use derive_more::{Display, Error};
 use std::{borrow, fmt, hash, ops, os::raw::c_uint};
-use thiserror::Error;
 
 extern crate alloc;
 #[cfg(feature = "serde")]
 extern crate serde;
 
-#[derive(Error, Debug, PartialEq, Eq)]
-pub enum Error {
-    #[error("Invalid url: \"{0}\"")]
-    ParseUrl(String),
+#[derive(Debug, Display, Error, PartialEq, Eq)]
+#[display(bound = "Input: std::fmt::Debug")]
+#[display(fmt = "Invalid url: {input:?}")]
+pub struct ParseUrlError<Input> {
+    input: Input,
 }
 
 /// Defines the type of the host.
@@ -148,23 +149,26 @@ impl Url {
     ///     .expect("This is a valid URL. Should have parsed it.");
     /// assert_eq!(out.protocol(), "https:");
     /// ```
-    pub fn parse(input: &str, base: Option<&str>) -> Result<Url, Error> {
+    pub fn parse<Input>(input: Input, base: Option<&str>) -> Result<Url, ParseUrlError<Input>>
+    where
+        Input: AsRef<str>,
+    {
         let url_aggregator = match base {
             Some(base) => unsafe {
                 ffi::ada_parse_with_base(
-                    input.as_ptr().cast(),
-                    input.len(),
+                    input.as_ref().as_ptr().cast(),
+                    input.as_ref().len(),
                     base.as_ptr().cast(),
                     base.len(),
                 )
             },
-            None => unsafe { ffi::ada_parse(input.as_ptr().cast(), input.len()) },
+            None => unsafe { ffi::ada_parse(input.as_ref().as_ptr().cast(), input.as_ref().len()) },
         };
 
         if unsafe { ffi::ada_is_valid(url_aggregator) } {
             Ok(url_aggregator.into())
         } else {
-            Err(Error::ParseUrl(input.to_owned()))
+            Err(ParseUrlError { input })
         }
     }
 
@@ -673,26 +677,26 @@ impl fmt::Debug for Url {
     }
 }
 
-impl TryFrom<&str> for Url {
-    type Error = Error;
+impl<'input> TryFrom<&'input str> for Url {
+    type Error = ParseUrlError<&'input str>;
 
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    fn try_from(value: &'input str) -> Result<Self, Self::Error> {
         Self::parse(value, None)
     }
 }
 
 impl TryFrom<String> for Url {
-    type Error = Error;
+    type Error = ParseUrlError<String>;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        Self::parse(&value, None)
+        Self::parse(value, None)
     }
 }
 
-impl TryFrom<&String> for Url {
-    type Error = Error;
+impl<'input> TryFrom<&'input String> for Url {
+    type Error = ParseUrlError<&'input String>;
 
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    fn try_from(value: &'input String) -> Result<Self, Self::Error> {
         Self::parse(value, None)
     }
 }
@@ -717,10 +721,12 @@ impl fmt::Display for Url {
 }
 
 impl std::str::FromStr for Url {
-    type Err = Error;
+    type Err = ParseUrlError<Box<str>>;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::parse(s, None)
+        Self::parse(s, None).map_err(|ParseUrlError { input }| ParseUrlError {
+            input: input.into(),
+        })
     }
 }
 
@@ -776,7 +782,6 @@ mod test {
         dbg!(&url);
         let error = url.unwrap_err();
         assert_eq!(error.to_string(), r#"Invalid url: "this is not a url""#);
-        assert!(matches!(error, Error::ParseUrl(_)));
     }
 
     #[test]


### PR DESCRIPTION
* `thiserror` has been replaced with `derive_more`:
  - `thiserror` cannot handle generic bounds.
* The `Error` type has been replaced with `ParseUrlError`:
  - It only has one variant anyway.
* This is a breaking change.