### PR TITLE
Adding libcpp tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,20 @@ jobs:
 
       - run: cargo fmt --all -- --check
 
+  libcpp:
+    name: libc++
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+          - os: ubuntu-latest
+          - os: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - run: cargo test --features=libcpp
+
   lint:
     name: Clippy
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
           - os: windows-latest
           - os: ubuntu-latest
           - os: macos-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Shows that https://github.com/ada-url/rust/issues/43 is invalid. The reporter probably attempts to use libc++ on a system that does not support libc++. There is nothing that this crate can do if you require it to use libc++ but libc++ is not available. It must fail. 