### PR TITLE
chore: update ada to v2.6.7

### DIFF
--- a/deps/ada.cpp
+++ b/deps/ada.cpp
@@ -1,4 +1,4 @@
-/* auto-generated on 2023-09-05 14:59:23 -0400. Do not edit! */
+/* auto-generated on 2023-09-05 16:55:45 -0400. Do not edit! */
 /* begin file src/ada.cpp */
 #include "ada.h"
 /* begin file src/checkers.cpp */
@@ -15009,7 +15009,7 @@ uint8_t ada_get_host_type(ada_url result) noexcept {
   return r->host_type;
 }
 
-uint8_t ada_get_schema_type(ada_url result) noexcept {
+uint8_t ada_get_scheme_type(ada_url result) noexcept {
   ada::result<ada::url_aggregator>& r = get_instance(result);
   if (!r) {
     return 0;

--- a/deps/ada.h
+++ b/deps/ada.h
@@ -1,4 +1,4 @@
-/* auto-generated on 2023-09-05 14:59:23 -0400. Do not edit! */
+/* auto-generated on 2023-09-05 16:55:45 -0400. Do not edit! */
 /* begin file include/ada.h */
 /**
  * @file ada.h
@@ -6926,14 +6926,14 @@ inline void url_search_params::sort() {
 #ifndef ADA_ADA_VERSION_H
 #define ADA_ADA_VERSION_H
 
-#define ADA_VERSION "2.6.6"
+#define ADA_VERSION "2.6.7"
 
 namespace ada {
 
 enum {
   ADA_VERSION_MAJOR = 2,
   ADA_VERSION_MINOR = 6,
-  ADA_VERSION_REVISION = 6,
+  ADA_VERSION_REVISION = 7,
 };
 
 }  // namespace ada

--- a/deps/ada_c.h
+++ b/deps/ada_c.h
@@ -69,7 +69,7 @@ ada_string ada_get_pathname(ada_url result);
 ada_string ada_get_search(ada_url result);
 ada_string ada_get_protocol(ada_url result);
 uint8_t ada_get_host_type(ada_url result);
-uint8_t ada_get_schema_type(ada_url result);
+uint8_t ada_get_scheme_type(ada_url result);
 
 // url_aggregator setters
 // if ada_is_valid(result)) is false, the setters have no effect


### PR DESCRIPTION
This PR updates ada to v2.6.7 which mainly fixes a typo and renames `ada_get_schema_type` to `ada_get_scheme_type`.