### PR TITLE
Improve error handling ergonomics (and docs around it)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,22 +8,9 @@ It fully supports the relevant [Unicode Technical Standard](https://www.unicode.
 
 ### Usage
 
-Here is an example illustrating a common usage:
-
-```Rust
-use ada_url::Url;
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut u = Url::parse("http://www.google:8080/love#drug", None).expect("bad url");
-    println!("port: {:?}", u.port());
-    println!("hash: {:?}", u.hash());
-    println!("pathname: {:?}", u.pathname());
-    println!("href: {:?}", u.href());
-    u.set_port(Some("9999"))?;
-    println!("href: {:?}", u.href());
-
-    Ok(())
-}
-```
+See [here](examples/simple.rs) for a usage example.
+You can run it locally with `cargo run --example simple`.
+Feel free to adjust it for exploring this crate further.
 
 #### Features
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## WHATWG URL parser for Rust
+# WHATWG URL parser for Rust
 
 Fast [WHATWG URL Specification](https://url.spec.whatwg.org) compliant URL parser for Rust.
 Well-tested and widely used by Node.js since [Node 18](https://nodejs.org/en/blog/release/v18.17.0).
@@ -6,7 +6,7 @@ Well-tested and widely used by Node.js since [Node 18](https://nodejs.org/en/blo
 The Ada library passes the full range of tests from the specification, across a wide range of platforms (e.g., Windows, Linux, macOS).
 It fully supports the relevant [Unicode Technical Standard](https://www.unicode.org/reports/tr46/#ToUnicode).
 
-### Usage
+## Usage
 
 See [here](examples/simple.rs) for a usage example.
 You can run it locally with `cargo run --example simple`.
@@ -27,7 +27,7 @@ Enabling this feature without `libc++` installed would cause compile error.
 
 Ada is fast. The benchmark below shows **3.34 times** faster URL parsing compared to `url`
 
-```
+```text
 parse/ada_url           time:   [2.0790 µs 2.0812 µs 2.0835 µs]
                         thrpt:  [369.84 MiB/s 370.25 MiB/s 370.65 MiB/s]
 
@@ -54,9 +54,9 @@ parse/url               time:   [6.9266 µs 6.9677 µs 7.0199 µs]
 | **[`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html)**                                                                                    | Used to declare that the type can be transferred across thread boundaries.                                                                                                                                    |
 | **[`Sync`](https://doc.rust-lang.org/stable/std/marker/trait.Sync.html)**                                                                             | Used to declare that the type is thread-safe.                                                                                                                                                                 |
 
-### Development
+## Development
 
-#### `justfile`
+### `justfile`
 
 The [`justfile`](./justfile) contains commands (called "recipes") that can be executed by [just](https://github.com/casey/just) for convenience.
 
@@ -72,7 +72,7 @@ just all
 just all --skip=libcpp,serde
 ```
 
-### License
+## License
 
 This code is made available under the Apache License 2.0 as well as the MIT license.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ See [here](examples/simple.rs) for a usage example.
 You can run it locally with `cargo run --example simple`.
 Feel free to adjust it for exploring this crate further.
 
-#### Features
+### Features
 
 **std:** Functionalities that require `std`.
 This feature is enabled by default, set `no-default-features` to `true` if you want `no-std`.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Here is an example illustrating a common usage:
 
 ```Rust
 use ada_url::Url;
-fn main() -> Result<(), ()> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut u = Url::parse("http://www.google:8080/love#drug", None).expect("bad url");
     println!("port: {:?}", u.port());
     println!("hash: {:?}", u.hash());

--- a/README.md
+++ b/README.md
@@ -12,14 +12,16 @@ Here is an example illustrating a common usage:
 
 ```Rust
 use ada_url::Url;
-fn main() {
+fn main() -> Result<(), ()> {
     let mut u = Url::parse("http://www.google:8080/love#drug", None).expect("bad url");
     println!("port: {:?}", u.port());
     println!("hash: {:?}", u.hash());
     println!("pathname: {:?}", u.pathname());
     println!("href: {:?}", u.href());
-    u.set_port(Some("9999"));
+    u.set_port(Some("9999"))?;
     println!("href: {:?}", u.href());
+
+    Ok(())
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Here is an example illustrating a common usage:
 ```Rust
 use ada_url::Url;
 fn main() {
-    let u = Url::parse("http://www.google:8080/love#drug", None).expect("bad url");
+    let mut u = Url::parse("http://www.google:8080/love#drug", None).expect("bad url");
     println!("port: {:?}", u.port());
     println!("hash: {:?}", u.hash());
     println!("pathname: {:?}", u.pathname());
     println!("href: {:?}", u.href());
-    u.set_port("9999");
+    u.set_port(Some("9999"));
     println!("href: {:?}", u.href());
 }
 ```

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,13 +1,22 @@
 use ada_url::Url;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut u = Url::parse("http://www.google:8080/love#drug", None).expect("bad url");
-    println!("port: {:?}", u.port());
-    println!("hash: {:?}", u.hash());
-    println!("pathname: {:?}", u.pathname());
-    println!("href: {:?}", u.href());
-    u.set_port(Some("9999"))?;
-    println!("href: {:?}", u.href());
+    let url = Url::parse("http://www.google:8080/love#drug", None).expect("bad url");
+
+    println!("port: {:?}", url.port());
+    println!("hash: {:?}", url.hash());
+    println!("pathname: {:?}", url.pathname());
+    println!("href: {:?}", url.href());
+
+    let mut url = url;
+
+    #[cfg(feature = "std")]
+    url.set_port(Some("9999"))?;
+
+    #[cfg(not(feature = "std"))]
+    url.set_port(Some("9999")).unwrap();
+
+    println!("href: {:?}", url.href());
 
     Ok(())
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,0 +1,13 @@
+use ada_url::Url;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut u = Url::parse("http://www.google:8080/love#drug", None).expect("bad url");
+    println!("port: {:?}", u.port());
+    println!("hash: {:?}", u.hash());
+    println!("pathname: {:?}", u.pathname());
+    println!("href: {:?}", u.href());
+    u.set_port(Some("9999"))?;
+    println!("href: {:?}", u.href());
+
+    Ok(())
+}

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,6 +1,6 @@
 use ada_url::Url;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() {
     let url = Url::parse("http://www.google:8080/love#drug", None).expect("bad url");
 
     println!("port: {:?}", url.port());
@@ -9,14 +9,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("href: {:?}", url.href());
 
     let mut url = url;
-
-    #[cfg(feature = "std")]
-    url.set_port(Some("9999"))?;
-
-    #[cfg(not(feature = "std"))]
-    url.set_port(Some("9999")).unwrap();
-
+    url.set_port(Some("9999")).expect("bad port");
     println!("href: {:?}", url.href());
-
-    Ok(())
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -14,7 +14,8 @@ pub struct ada_string {
 }
 
 impl ada_string {
-    pub fn as_str(&self) -> &'static str {
+    #[must_use]
+    pub const fn as_str(&self) -> &'static str {
         unsafe {
             let slice = core::slice::from_raw_parts(self.data.cast(), self.length);
             core::str::from_utf8_unchecked(slice)

--- a/src/idna.rs
+++ b/src/idna.rs
@@ -1,6 +1,6 @@
 use crate::ffi;
 
-/// IDNA struct implements the to_ascii and to_unicode functions from the Unicode Technical
+/// IDNA struct implements the `to_ascii` and `to_unicode` functions from the Unicode Technical
 /// Standard supporting a wide range of systems. It is suitable for URL parsing.
 /// For more information, [read the specification](https://www.unicode.org/reports/tr46/#ToUnicode)
 pub struct Idna {}
@@ -15,6 +15,7 @@ impl Idna {
     /// use ada_url::Idna;
     /// assert_eq!(Idna::unicode("xn--meagefactory-m9a.ca"), "meßagefactory.ca");
     /// ```
+    #[must_use]
     pub fn unicode(input: &str) -> &str {
         unsafe {
             let out = ffi::ada_idna_to_unicode(input.as_ptr().cast(), input.len());
@@ -32,6 +33,7 @@ impl Idna {
     /// use ada_url::Idna;
     /// assert_eq!(Idna::ascii("meßagefactory.ca"), "xn--meagefactory-m9a.ca");
     /// ```
+    #[must_use]
     pub fn ascii(input: &str) -> &str {
         unsafe {
             let out = ffi::ada_idna_to_ascii(input.as_ptr().cast(), input.len());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,18 +179,14 @@ impl From<*mut ffi::ada_url> for Url {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Display)]
-#[cfg_attr(feature = "std", derive(derive_more::Error))] // error still requires std: https://github.com/rust-lang/rust/issues/103765
-pub struct SetterError;
-
-type SetterResult = Result<(), SetterError>;
+type SetterResult = Result<(), ()>;
 
 #[inline]
 const fn setter_result(successful: bool) -> SetterResult {
     if successful {
         Ok(())
     } else {
-        Err(SetterError)
+        Err(())
     }
 }
 
@@ -299,6 +295,7 @@ impl Url {
     /// url.set_href("https://lemire.me").unwrap();
     /// assert_eq!(url.href(), "https://lemire.me/");
     /// ```
+    #[allow(clippy::result_unit_err)]
     pub fn set_href(&mut self, input: &str) -> SetterResult {
         setter_result(unsafe { ffi::ada_set_href(self.0, input.as_ptr().cast(), input.len()) })
     }
@@ -327,6 +324,7 @@ impl Url {
     /// url.set_username(Some("username")).unwrap();
     /// assert_eq!(url.href(), "https://username@yagiz.co/");
     /// ```
+    #[allow(clippy::result_unit_err)]
     pub fn set_username(&mut self, input: Option<&str>) -> SetterResult {
         setter_result(unsafe {
             ffi::ada_set_username(
@@ -361,6 +359,7 @@ impl Url {
     /// url.set_password(Some("password")).unwrap();
     /// assert_eq!(url.href(), "https://:password@yagiz.co/");
     /// ```
+    #[allow(clippy::result_unit_err)]
     pub fn set_password(&mut self, input: Option<&str>) -> SetterResult {
         setter_result(unsafe {
             ffi::ada_set_password(
@@ -398,6 +397,7 @@ impl Url {
     /// url.set_port(Some("8080")).unwrap();
     /// assert_eq!(url.href(), "https://yagiz.co:8080/");
     /// ```
+    #[allow(clippy::result_unit_err)]
     pub fn set_port(&mut self, input: Option<&str>) -> SetterResult {
         if let Some(value) = input {
             setter_result(unsafe { ffi::ada_set_port(self.0, value.as_ptr().cast(), value.len()) })
@@ -469,6 +469,7 @@ impl Url {
     /// url.set_host(Some("localhost:3000")).unwrap();
     /// assert_eq!(url.href(), "https://localhost:3000/");
     /// ```
+    #[allow(clippy::result_unit_err)]
     pub fn set_host(&mut self, input: Option<&str>) -> SetterResult {
         setter_result(unsafe {
             ffi::ada_set_host(
@@ -507,6 +508,7 @@ impl Url {
     /// url.set_hostname(Some("localhost")).unwrap();
     /// assert_eq!(url.href(), "https://localhost/");
     /// ```
+    #[allow(clippy::result_unit_err)]
     pub fn set_hostname(&mut self, input: Option<&str>) -> SetterResult {
         setter_result(unsafe {
             ffi::ada_set_hostname(
@@ -541,6 +543,7 @@ impl Url {
     /// url.set_pathname(Some("/contact")).unwrap();
     /// assert_eq!(url.href(), "https://yagiz.co/contact");
     /// ```
+    #[allow(clippy::result_unit_err)]
     pub fn set_pathname(&mut self, input: Option<&str>) -> SetterResult {
         setter_result(unsafe {
             ffi::ada_set_pathname(
@@ -611,6 +614,7 @@ impl Url {
     /// url.set_protocol("http").unwrap();
     /// assert_eq!(url.href(), "http://yagiz.co/");
     /// ```
+    #[allow(clippy::result_unit_err)]
     pub fn set_protocol(&mut self, input: &str) -> SetterResult {
         setter_result(unsafe { ffi::ada_set_protocol(self.0, input.as_ptr().cast(), input.len()) })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,9 +180,8 @@ impl From<*mut ffi::ada_url> for Url {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Display)]
+#[cfg_attr(feature = "std", derive(derive_more::Error))] // error still requires std: https://github.com/rust-lang/rust/issues/103765
 pub struct SetterError;
-
-impl std::error::Error for SetterError {}
 
 type SetterResult = Result<(), SetterError>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,14 +179,19 @@ impl From<*mut ffi::ada_url> for Url {
     }
 }
 
-type SetterResult = Result<(), ()>;
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Display)]
+pub struct SetterError;
+
+impl std::error::Error for SetterError {}
+
+type SetterResult = Result<(), SetterError>;
 
 #[inline]
 fn setter_result(successful: bool) -> SetterResult {
     if successful {
         Ok(())
     } else {
-        Err(())
+        Err(SetterError)
     }
 }
 
@@ -290,7 +295,6 @@ impl Url {
     /// url.set_href("https://lemire.me").unwrap();
     /// assert_eq!(url.href(), "https://lemire.me/");
     /// ```
-    #[allow(clippy::result_unit_err)]
     pub fn set_href(&mut self, input: &str) -> SetterResult {
         setter_result(unsafe { ffi::ada_set_href(self.0, input.as_ptr().cast(), input.len()) })
     }
@@ -318,7 +322,6 @@ impl Url {
     /// url.set_username(Some("username")).unwrap();
     /// assert_eq!(url.href(), "https://username@yagiz.co/");
     /// ```
-    #[allow(clippy::result_unit_err)]
     pub fn set_username(&mut self, input: Option<&str>) -> SetterResult {
         setter_result(unsafe {
             ffi::ada_set_username(
@@ -352,7 +355,6 @@ impl Url {
     /// url.set_password(Some("password")).unwrap();
     /// assert_eq!(url.href(), "https://:password@yagiz.co/");
     /// ```
-    #[allow(clippy::result_unit_err)]
     pub fn set_password(&mut self, input: Option<&str>) -> SetterResult {
         setter_result(unsafe {
             ffi::ada_set_password(
@@ -389,7 +391,6 @@ impl Url {
     /// url.set_port(Some("8080")).unwrap();
     /// assert_eq!(url.href(), "https://yagiz.co:8080/");
     /// ```
-    #[allow(clippy::result_unit_err)]
     pub fn set_port(&mut self, input: Option<&str>) -> SetterResult {
         match input {
             Some(value) => setter_result(unsafe {
@@ -462,7 +463,6 @@ impl Url {
     /// url.set_host(Some("localhost:3000")).unwrap();
     /// assert_eq!(url.href(), "https://localhost:3000/");
     /// ```
-    #[allow(clippy::result_unit_err)]
     pub fn set_host(&mut self, input: Option<&str>) -> SetterResult {
         setter_result(unsafe {
             ffi::ada_set_host(
@@ -500,7 +500,6 @@ impl Url {
     /// url.set_hostname(Some("localhost")).unwrap();
     /// assert_eq!(url.href(), "https://localhost/");
     /// ```
-    #[allow(clippy::result_unit_err)]
     pub fn set_hostname(&mut self, input: Option<&str>) -> SetterResult {
         setter_result(unsafe {
             ffi::ada_set_hostname(
@@ -534,7 +533,6 @@ impl Url {
     /// url.set_pathname(Some("/contact")).unwrap();
     /// assert_eq!(url.href(), "https://yagiz.co/contact");
     /// ```
-    #[allow(clippy::result_unit_err)]
     pub fn set_pathname(&mut self, input: Option<&str>) -> SetterResult {
         setter_result(unsafe {
             ffi::ada_set_pathname(
@@ -603,7 +601,6 @@ impl Url {
     /// url.set_protocol("http").unwrap();
     /// assert_eq!(url.href(), "http://yagiz.co/");
     /// ```
-    #[allow(clippy::result_unit_err)]
     pub fn set_protocol(&mut self, input: &str) -> SetterResult {
         setter_result(unsafe { ffi::ada_set_protocol(self.0, input.as_ptr().cast(), input.len()) })
     }


### PR DESCRIPTION
- **docs: Fix sample code**
- **docs: Use unused `Result`**
- **feat!: `Error` for `SetterResult`**
- **chore: Fix various `clippy` lints**
- **docs: Dedicated `examples/`**
- **docs: Apply Markdown lints**
