### PR TITLE
fix(ffi/ada_free_owned_string): c parameter is passed by value

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -126,8 +126,8 @@ mod tests {
     #[test]
     fn ada_free_owned_string_works() {
         let str = "meßagefactory.ca";
-        let result = unsafe {ffi::ada_idna_to_ascii(str.as_ptr().cast(), str.len())};
+        let result = unsafe { ffi::ada_idna_to_ascii(str.as_ptr().cast(), str.len()) };
         assert_eq!(result.as_ref(), "xn--meagefactory-m9a.ca");
-        unsafe {ffi::ada_free_owned_string(result)};
+        unsafe { ffi::ada_free_owned_string(result) };
     }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -59,7 +59,7 @@ extern "C" {
         base_length: usize,
     ) -> *mut ada_url;
     pub fn ada_free(url: *mut ada_url);
-    pub fn ada_free_owned_string(url: *mut ada_owned_string);
+    pub fn ada_free_owned_string(url: ada_owned_string);
     pub fn ada_copy(url: *mut ada_url) -> *mut ada_url;
     pub fn ada_is_valid(url: *mut ada_url) -> bool;
     pub fn ada_can_parse(url: *const c_char, length: usize) -> bool;

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -118,3 +118,16 @@ extern "C" {
     pub fn ada_idna_to_unicode(input: *const c_char, length: usize) -> ada_owned_string;
     pub fn ada_idna_to_ascii(input: *const c_char, length: usize) -> ada_owned_string;
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::ffi;
+
+    #[test]
+    fn ada_free_owned_string_works() {
+        let str = "meßagefactory.ca";
+        let result = unsafe {ffi::ada_idna_to_ascii(str.as_ptr().cast(), str.len())};
+        assert_eq!(result.as_ref(), "xn--meagefactory-m9a.ca");
+        unsafe {ffi::ada_free_owned_string(result)};
+    }
+}


### PR DESCRIPTION
While working on #63, I noticed that my Drop wasn't correctly working because the Rust Implementation was assuming that the C parameters are passed by pointer, while they are actually passed by value

Then on a deeper check of the C code, found it at https://github.com/ada-url/ada/blob/1227f60798b05a04412af867d2f13ed20ead9243/include/ada_c.h#L53C6-L53C27.

BREAKING CHANGE: ada_free_owned_string parameter pass by value not pointer. Closes #64