### PR TITLE
build(justfile): add format support

### DIFF
--- a/justfile
+++ b/justfile
@@ -3,9 +3,14 @@ _default:
 
 # run doc, clippy, and test recipies
 all *args:
+  just fmt {{args}}
   just doc {{args}}
   just clippy {{args}}
   just test {{args}}
+
+# Format all code
+fmt *args:
+  cargo fmt --all {{args}}
 
 # run tests on all feature combinations
 test *args:


### PR DESCRIPTION
Allows for formatting of source code when running just all

Using the [fmt naming from Just's own](https://github.com/casey/just/blob/d15dad66c9d1cd342b99d0de2d2e99a610ee2fd8/justfile#L39)

This would ideally reduce silly mistakes on commits such as my own in #65.