### PR TITLE
In functions using ada_owned_string, return ada_owned_string instead of &str

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,6 +1,9 @@
 #![allow(non_camel_case_types)]
 use core::ffi::{c_char, c_uint};
 
+#[cfg(feature = "std")]
+extern crate std;
+
 #[repr(C)]
 pub struct ada_url {
     _unused: [u8; 0],
@@ -35,6 +38,13 @@ impl AsRef<str> for ada_owned_string {
             let slice = core::slice::from_raw_parts(self.data.cast(), self.length);
             core::str::from_utf8_unchecked(slice)
         }
+    }
+}
+
+#[cfg(feature = "std")]
+impl ToString for ada_owned_string {
+    fn to_string(&self) -> std::string::String {
+        self.as_ref().to_owned()
     }
 }
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -38,6 +38,19 @@ impl AsRef<str> for ada_owned_string {
     }
 }
 
+impl Drop for ada_owned_string {
+    fn drop(&mut self) {
+        // @note This is needed because ada_free_owned_string accepts by value
+        let copy = ada_owned_string {
+            data: self.data,
+            length: self.length,
+        };
+        unsafe {
+            ada_free_owned_string(copy);
+        };
+    }
+}
+
 #[repr(C)]
 pub struct ada_url_components {
     pub protocol_end: u32,

--- a/src/idna.rs
+++ b/src/idna.rs
@@ -13,15 +13,11 @@ impl Idna {
     ///
     /// ```
     /// use ada_url::Idna;
-    /// assert_eq!(Idna::unicode("xn--meagefactory-m9a.ca"), "meßagefactory.ca");
+    /// assert_eq!(Idna::unicode("xn--meagefactory-m9a.ca").as_ref(), "meßagefactory.ca");
     /// ```
     #[must_use]
-    pub fn unicode(input: &str) -> &str {
-        unsafe {
-            let out = ffi::ada_idna_to_unicode(input.as_ptr().cast(), input.len());
-            let slice = core::slice::from_raw_parts(out.data.cast(), out.length);
-            core::str::from_utf8_unchecked(slice)
-        }
+    pub fn unicode(input: &str) -> ffi::ada_owned_string {
+        unsafe { ffi::ada_idna_to_unicode(input.as_ptr().cast(), input.len()) }
     }
 
     /// Process international domains according to the UTS #46 standard.
@@ -31,15 +27,11 @@ impl Idna {
     ///
     /// ```
     /// use ada_url::Idna;
-    /// assert_eq!(Idna::ascii("meßagefactory.ca"), "xn--meagefactory-m9a.ca");
+    /// assert_eq!(Idna::ascii("meßagefactory.ca").as_ref(), "xn--meagefactory-m9a.ca");
     /// ```
     #[must_use]
-    pub fn ascii(input: &str) -> &str {
-        unsafe {
-            let out = ffi::ada_idna_to_ascii(input.as_ptr().cast(), input.len());
-            let slice = core::slice::from_raw_parts(out.data.cast(), out.length);
-            core::str::from_utf8_unchecked(slice)
-        }
+    pub fn ascii(input: &str) -> ffi::ada_owned_string {
+        unsafe { ffi::ada_idna_to_ascii(input.as_ptr().cast(), input.len()) }
     }
 }
 
@@ -49,11 +41,17 @@ mod tests {
 
     #[test]
     fn unicode_should_work() {
-        assert_eq!(Idna::unicode("xn--meagefactory-m9a.ca"), "meßagefactory.ca");
+        assert_eq!(
+            Idna::unicode("xn--meagefactory-m9a.ca").as_ref(),
+            "meßagefactory.ca"
+        );
     }
 
     #[test]
     fn ascii_should_work() {
-        assert_eq!(Idna::ascii("meßagefactory.ca"), "xn--meagefactory-m9a.ca");
+        assert_eq!(
+            Idna::ascii("meßagefactory.ca").as_ref(),
+            "xn--meagefactory-m9a.ca"
+        );
     }
 }

--- a/src/idna.rs
+++ b/src/idna.rs
@@ -1,4 +1,11 @@
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg_attr(not(feature = "std"), allow(unused_imports))]
 use crate::ffi;
+
+#[cfg(feature = "std")]
+use std::string::String;
 
 /// IDNA struct implements the `to_ascii` and `to_unicode` functions from the Unicode Technical
 /// Standard supporting a wide range of systems. It is suitable for URL parsing.
@@ -13,11 +20,12 @@ impl Idna {
     ///
     /// ```
     /// use ada_url::Idna;
-    /// assert_eq!(Idna::unicode("xn--meagefactory-m9a.ca").as_ref(), "meßagefactory.ca");
+    /// assert_eq!(Idna::unicode("xn--meagefactory-m9a.ca"), "meßagefactory.ca");
     /// ```
     #[must_use]
-    pub fn unicode(input: &str) -> ffi::ada_owned_string {
-        unsafe { ffi::ada_idna_to_unicode(input.as_ptr().cast(), input.len()) }
+    #[cfg(feature = "std")]
+    pub fn unicode(input: &str) -> String {
+        unsafe { ffi::ada_idna_to_unicode(input.as_ptr().cast(), input.len()) }.to_string()
     }
 
     /// Process international domains according to the UTS #46 standard.
@@ -27,31 +35,29 @@ impl Idna {
     ///
     /// ```
     /// use ada_url::Idna;
-    /// assert_eq!(Idna::ascii("meßagefactory.ca").as_ref(), "xn--meagefactory-m9a.ca");
+    /// assert_eq!(Idna::ascii("meßagefactory.ca"), "xn--meagefactory-m9a.ca");
     /// ```
     #[must_use]
-    pub fn ascii(input: &str) -> ffi::ada_owned_string {
-        unsafe { ffi::ada_idna_to_ascii(input.as_ptr().cast(), input.len()) }
+    #[cfg(feature = "std")]
+    pub fn ascii(input: &str) -> String {
+        unsafe { ffi::ada_idna_to_ascii(input.as_ptr().cast(), input.len()) }.to_string()
     }
 }
 
 #[cfg(test)]
 mod tests {
+    #[cfg_attr(not(feature = "std"), allow(unused_imports))]
     use crate::idna::*;
 
     #[test]
     fn unicode_should_work() {
-        assert_eq!(
-            Idna::unicode("xn--meagefactory-m9a.ca").as_ref(),
-            "meßagefactory.ca"
-        );
+        #[cfg(feature = "std")]
+        assert_eq!(Idna::unicode("xn--meagefactory-m9a.ca"), "meßagefactory.ca");
     }
 
     #[test]
     fn ascii_should_work() {
-        assert_eq!(
-            Idna::ascii("meßagefactory.ca").as_ref(),
-            "xn--meagefactory-m9a.ca"
-        );
+        #[cfg(feature = "std")]
+        assert_eq!(Idna::ascii("meßagefactory.ca"), "xn--meagefactory-m9a.ca");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,12 @@ pub mod ffi;
 mod idna;
 pub use idna::Idna;
 
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(feature = "std")]
+use std::string::String;
+
 use core::{borrow, ffi::c_uint, fmt, hash, ops};
 use derive_more::Display;
 
@@ -267,11 +273,12 @@ impl Url {
     /// use ada_url::Url;
     ///
     /// let url = Url::parse("blob:https://example.com/foo", None).expect("Invalid URL");
-    /// assert_eq!(url.origin().as_ref(), "https://example.com");
+    /// assert_eq!(url.origin(), "https://example.com");
     /// ```
     #[must_use]
-    pub fn origin(&self) -> ffi::ada_owned_string {
-        unsafe { ffi::ada_get_origin(self.0) }
+    #[cfg(feature = "std")]
+    pub fn origin(&self) -> String {
+        unsafe { ffi::ada_get_origin(self.0) }.to_string()
     }
 
     /// Return the parsed version of the URL with all components.
@@ -945,7 +952,10 @@ mod test {
             None,
         )
         .expect("Should have parsed a simple url");
-        assert_eq!(out.origin().as_ref(), "https://google.com:9090");
+
+        #[cfg(feature = "std")]
+        assert_eq!(out.origin(), "https://google.com:9090");
+
         assert_eq!(
             out.href(),
             "https://username:password@google.com:9090/search?query#hash"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,15 +267,11 @@ impl Url {
     /// use ada_url::Url;
     ///
     /// let url = Url::parse("blob:https://example.com/foo", None).expect("Invalid URL");
-    /// assert_eq!(url.origin(), "https://example.com");
+    /// assert_eq!(url.origin().as_ref(), "https://example.com");
     /// ```
     #[must_use]
-    pub fn origin(&self) -> &str {
-        unsafe {
-            let out = ffi::ada_get_origin(self.0);
-            let slice = core::slice::from_raw_parts(out.data.cast(), out.length);
-            core::str::from_utf8_unchecked(slice)
-        }
+    pub fn origin(&self) -> ffi::ada_owned_string {
+        unsafe { ffi::ada_get_origin(self.0) }
     }
 
     /// Return the parsed version of the URL with all components.
@@ -949,7 +945,7 @@ mod test {
             None,
         )
         .expect("Should have parsed a simple url");
-        assert_eq!(out.origin(), "https://google.com:9090");
+        assert_eq!(out.origin().as_ref(), "https://google.com:9090");
         assert_eq!(
             out.href(),
             "https://username:password@google.com:9090/search?query#hash"


### PR DESCRIPTION
## Why

1. The previous approach would leak memory

## Advantages

1. Returns an owned string
2. No memory leaks

## Disadvantages

1. ada_owned_string now implements Drop trait.   
This would lead to the freeing of memory upon its going out of scope breaking existing code.   
This behaviour is probably more Rust-like but breaks user-space.  
The alternative is to not impement Drop and it could be done.  
However, this would make it user space's responsibility and hence not exactly an ideal behaviour
2. Usage of as_ref needed to convert to &str as can be seen in unit tests.  
This can be resolved by probably implementing conversion functions if needed for Display, to_string etc. in std mode for end-user ease.

## Another approach

1. Returning String  
Would lead to a major breaking change.  
The approach would lead to all 3 functions no longer working in no-std mode.  
That is probably not ideal.


Closes #63 