### PR TITLE
ci: add github release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
       matrix:
         include:
         - os: windows-latest
-        - os: ubuntu-latest
         - os: macos-latest
         - os: ubuntu-latest
           env:
@@ -83,6 +82,8 @@ jobs:
 
     - name: Install Rust toolchain
       uses: moonrepo/setup-rust@v1
+      with:
+        bins: cargo-edit
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -90,6 +91,17 @@ jobs:
       run: cargo publish
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+    - name: Update Cargo.toml version
+      env:
+        NEW_VERSION: ${{ inputs.publish-tag }}
+      run: |
+        VERSION=${NEW_VERSION#v}
+        cargo set-version "${VERSION}"
+
+        git add Cargo.toml
+        git commit -m "chore: bump version to ${NEW_VERSION}"
+        git push
 
     - name: Tag the version
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,17 +80,14 @@ jobs:
       with:
         persist-credentials: true
 
-    - name: Install Rust toolchain
-      uses: moonrepo/setup-rust@v1
-      with:
-        bins: cargo-edit
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Publish to crates.io
       run: cargo publish
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-edit
 
     - name: Update Cargo.toml version
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,11 +80,6 @@ jobs:
       with:
         persist-credentials: true
 
-    - name: Publish to crates.io
-      run: cargo publish
-      env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
     - uses: taiki-e/install-action@v2
       with:
         tool: cargo-edit
@@ -103,9 +98,14 @@ jobs:
     - name: Tag the version
       env:
         GIT_TAG: ${{ inputs.publish-tag }}
-      run: |
+      run: |+
         git tag "${GIT_TAG}"
         git push origin "${GIT_TAG}"
+
+    - name: Publish to crates.io
+      run: cargo publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
     - name: Create github release
       uses: taiki-e/create-gh-release-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,108 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish-tag:
+        description: 'The tag of the version to publish'
+        required: true
+        type: string
+
+concurrency:
+  group: release
+
+env:
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test-release:
+    name: Check & Test release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - os: windows-latest
+        - os: ubuntu-latest
+        - os: macos-latest
+        - os: ubuntu-latest
+          env:
+            CARGO_BUILD_TARGET: wasm32-wasi
+            CARGO_TARGET_WASM32_WASI_RUNNER: /home/runner/.wasmtime/bin/wasmtime --dir=.
+    runs-on: ${{ matrix.os }}
+    if: github.ref == 'refs/heads/main'
+    env: ${{ matrix.env || fromJSON('{}') }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
+    - name: Install Wasm deps
+      if: matrix.env.CARGO_BUILD_TARGET == 'wasm32-wasi'
+      run: |
+        rustup target add wasm32-wasi
+        curl -LO https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sdk_20.0_amd64.deb
+        sudo dpkg --install wasi-sdk_20.0_amd64.deb
+        curl https://wasmtime.dev/install.sh -sSf | bash
+
+    - uses: Swatinem/rust-cache@v2
+      with:
+        shared-key: release
+        save-if: ${{ github.ref_name == 'main' }}
+
+    - run: rustup show
+
+    - name: Install cargo-hack
+      uses: taiki-e/install-action@cargo-hack
+
+    - name: Clippy
+      run: cargo hack clippy --feature-powerset -- -D warnings
+
+    - name: Test
+      run: cargo hack test --feature-powerset
+
+    - name: Check Documentation
+      env:
+        RUSTDOCFLAGS: '-D warnings'
+      run: cargo hack doc --feature-powerset
+
+    - name: Check semver
+      if: matrix.os == 'ubuntu-latest'
+      uses: obi1kenobi/cargo-semver-checks-action@v2
+
+  publish-release:
+    name: Publish release
+    needs: test-release
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: true
+
+    - name: Install Rust toolchain
+      uses: moonrepo/setup-rust@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Publish to crates.io
+      run: cargo publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+    - name: Tag the version
+      env:
+        GIT_TAG: ${{ inputs.publish-tag }}
+      run: |
+        git tag "${GIT_TAG}"
+        git push origin "${GIT_TAG}"
+
+    - name: Create github release
+      uses: taiki-e/create-gh-release-action@v1
+      with:
+        branch: main
+        ref: refs/tags/"${GIT_TAG}"
+      env:
+        GIT_TAG: ${{ inputs.publish-tag }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes
Adds a release workflow that can be manually triggered via workflow dispatch.
- First runs a test stage similar to `ci.yml` that:
  - Tests across multiple platforms (Windows, Ubuntu, MacOS)
  - Includes WASM testing
  - Runs cargo-semver-check on Ubuntu runs
- If tests pass, runs a publish stage that:
  - Publishes to crates.io
  - Creates git tags
  - Creates GitHub releases

## Prerequisites
- `CARGO_REGISTRY_TOKEN` secret must be configured in repository settings

Closes #72

> A future improvement could be to use a reusable workflow for the test-release workflow.