### PR TITLE
add a 'links' key to the manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["parser-implementations", "web-programming", "encoding", "parsing"
 repository = "https://github.com/ada-url/rust"
 homepage = "https://ada-url.com"
 license = "MIT OR Apache-2.0"
+links = "ada-url"
 
 [[bench]]
 name = "parse"


### PR DESCRIPTION
In order to prevent problems with duplicate symbols in the future.

See: https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key